### PR TITLE
This makes a "spriteshape" glow

### DIFF
--- a/Assets/SpriteGlow/Runtime/SpriteShapeGlowEffect
+++ b/Assets/SpriteGlow/Runtime/SpriteShapeGlowEffect
@@ -9,7 +9,7 @@ namespace SpriteShapeGlowEffect
     /// </summary>
     [AddComponentMenu("Effects/Sprite Glow")]
     [RequireComponent(typeof(SpriteShapeRenderer)), DisallowMultipleComponent, ExecuteInEditMode]
-    public class SpriteShapeGlow : MonoBehaviour
+    public class SpriteShapeGlowEffect : MonoBehaviour
     {
         
         public SpriteShapeRenderer Renderer { get; private set; }

--- a/Assets/SpriteGlow/Runtime/SpriteShapeGlowEffect
+++ b/Assets/SpriteGlow/Runtime/SpriteShapeGlowEffect
@@ -1,0 +1,113 @@
+using UnityEngine;
+using UnityEngine.U2D;
+
+namespace SpriteShapeGlowEffect
+{
+    /// <summary>
+    /// Adds an HDR outline over the <see cref="SpriteRenderer"/>'s sprite borders.
+    /// Can be used in conjuction with bloom post-processing to create a glow effect.
+    /// </summary>
+    [AddComponentMenu("Effects/Sprite Glow")]
+    [RequireComponent(typeof(SpriteShapeRenderer)), DisallowMultipleComponent, ExecuteInEditMode]
+    public class SpriteShapeGlow : MonoBehaviour
+    {
+        
+        public SpriteShapeRenderer Renderer { get; private set; }
+        public Color GlowColor
+        {
+            get => glowColor;
+            set { if (glowColor != value) { glowColor = value; SetMaterialProperties(); } }
+        }
+        public float GlowBrightness
+        {
+            get => glowBrightness;
+            set { if (glowBrightness != value) { glowBrightness = value; SetMaterialProperties(); } }
+        }
+        public int OutlineWidth
+        {
+            get => outlineWidth;
+            set { if (outlineWidth != value) { outlineWidth = value; SetMaterialProperties(); } }
+        }
+        public float AlphaThreshold
+        {
+            get => alphaThreshold;
+            set { if (alphaThreshold != value) { alphaThreshold = value; SetMaterialProperties(); } }
+        }
+        public bool DrawOutside
+        {
+            get => drawOutside;
+            set { if (drawOutside != value) { drawOutside = value; SetMaterialProperties(); } }
+        }
+        public bool EnableInstancing
+        {
+            get => enableInstancing;
+            set { if (enableInstancing != value) { enableInstancing = value; SetMaterialProperties(); } }
+        }
+
+        [Tooltip("Base color of the glow.")]
+        [SerializeField] private Color glowColor = Color.white;
+        [Tooltip("The brightness (power) of the glow."), Range(1, 10)]
+        [SerializeField] private float glowBrightness = 2f;
+        [Tooltip("Width of the outline, in texels."), Range(0, 10)]
+        [SerializeField] private int outlineWidth = 1;
+        [Tooltip("Threshold to determine sprite borders."), Range(0f, 1f)]
+        [SerializeField] private float alphaThreshold = .01f;
+        [Tooltip("Whether the outline should only be drawn outside of the sprite borders. Make sure sprite texture has sufficient transparent space for the required outline width.")]
+        [SerializeField] private bool drawOutside = false;
+        [Tooltip("Whether to enable GPU instancing.")]
+        [SerializeField] private bool enableInstancing = false;
+
+        private static readonly int isOutlineEnabledId = Shader.PropertyToID("_IsOutlineEnabled");
+        private static readonly int outlineColorId = Shader.PropertyToID("_OutlineColor");
+        private static readonly int outlineSizeId = Shader.PropertyToID("_OutlineSize");
+        private static readonly int alphaThresholdId = Shader.PropertyToID("_AlphaThreshold");
+
+        private MaterialPropertyBlock materialProperties;
+
+        private void Awake()
+        {
+            Renderer = GetComponent<SpriteShapeRenderer>();
+        }
+
+        private void OnEnable()
+        {
+            SetMaterialProperties();
+        }
+
+        private void OnDisable()
+        {
+            SetMaterialProperties();
+        }
+
+        private void OnValidate()
+        {
+            if (!isActiveAndEnabled) return;
+
+            // Update material properties when changing serialized fields with editor GUI.
+            SetMaterialProperties();
+        }
+
+        private void OnDidApplyAnimationProperties()
+        {
+            // Update material properties when changing serialized fields with Unity animation.
+            SetMaterialProperties();
+        }
+
+        private void SetMaterialProperties()
+        {
+            if (!Renderer) return;
+
+            Renderer.sharedMaterial = SpriteShapeGlowMaterial.GetSharedFor(this);
+
+            if (materialProperties == null) // Initializing it at `Awake` or `OnEnable` causes nullref in editor in some cases.
+                materialProperties = new MaterialPropertyBlock();
+
+            materialProperties.SetFloat(isOutlineEnabledId, isActiveAndEnabled ? 1 : 0);
+            materialProperties.SetColor(outlineColorId, GlowColor * GlowBrightness);
+            materialProperties.SetFloat(outlineSizeId, OutlineWidth);
+            materialProperties.SetFloat(alphaThresholdId, AlphaThreshold);
+
+            Renderer.SetPropertyBlock(materialProperties);
+        }
+    }
+}

--- a/Assets/SpriteGlow/Runtime/SpriteShapeGlowMaterial
+++ b/Assets/SpriteGlow/Runtime/SpriteShapeGlowMaterial
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.U2D;
+
+namespace SpriteGlow
+{
+    public class SpriteShapeGlowMaterial : Material
+    {
+        //public Texture SpriteTexture => mainTexture;
+        public bool DrawOutside => IsKeywordEnabled(outsideMaterialKeyword);
+        public bool InstancingEnabled => enableInstancing;
+
+        private const string outlineShaderName = "Sprites/Outline";
+        private const string outsideMaterialKeyword = "SPRITE_OUTLINE_OUTSIDE";
+
+        private static readonly Shader outlineShader = Shader.Find(outlineShaderName);
+        private static readonly List<SpriteShapeGlowMaterial> sharedMaterials = new List<SpriteShapeGlowMaterial>();
+
+        public SpriteShapeGlowMaterial(bool drawOutside = false, bool instancingEnabled = false)
+            : base(outlineShader)
+        {
+            if (!outlineShader) Debug.LogError($"`{outlineShaderName}` shader not found. Make sure the shader is included to the build.");
+
+
+            if (drawOutside) EnableKeyword(outsideMaterialKeyword);
+            if (instancingEnabled) enableInstancing = true;
+        }
+
+        public static Material GetSharedFor(SpriteShapeGlow spriteGlow)
+        {
+            for (int i = 0; i < sharedMaterials.Count; i++)
+            {
+                if (
+                    sharedMaterials[i].DrawOutside == spriteGlow.DrawOutside &&
+                    sharedMaterials[i].InstancingEnabled == spriteGlow.EnableInstancing)
+                    return sharedMaterials[i];
+            }
+
+            var material = new SpriteShapeGlowMaterial(spriteGlow.DrawOutside, spriteGlow.EnableInstancing);
+            material.hideFlags = HideFlags.DontSaveInBuild | HideFlags.DontSaveInEditor | HideFlags.NotEditable;
+            sharedMaterials.Add(material);
+
+            return material;
+        }
+    }
+}

--- a/Assets/SpriteGlow/Runtime/SpriteShapeGlowMaterial
+++ b/Assets/SpriteGlow/Runtime/SpriteShapeGlowMaterial
@@ -26,7 +26,7 @@ namespace SpriteGlow
             if (instancingEnabled) enableInstancing = true;
         }
 
-        public static Material GetSharedFor(SpriteShapeGlow spriteGlow)
+        public static Material GetSharedFor(SpriteShapeGlowEffect spriteGlow)
         {
             for (int i = 0; i < sharedMaterials.Count; i++)
             {


### PR DESCRIPTION
I wanted to use "spriteshape" with your awesome package. 

You can read more about spriteshape [here](https://docs.unity3d.com/Packages/com.unity.2d.spriteshape@3.0/manual/index.html)

I just changed the spriteRenderer with spriteShapeRenderer and made it into a separate file. 

It could also be written directly in your script, with a simple check, if you either want to use, spriteRenderer || spriteShapeRenderer 